### PR TITLE
Enhance SSE demo realism and Gatling load test

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <h1>📈 Live Crypto Price Feed</h1>
+  <p id="status">Connecting...</p>
   <div id="ticker-container">
     <table>
       <thead>

--- a/sse-demo-app/server.js
+++ b/sse-demo-app/server.js
@@ -12,6 +12,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 const clients = [];
 let prices = generateInitialPrices();
+let eventId = 0;
 
 app.get('/prices', (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');
@@ -19,9 +20,25 @@ app.get('/prices', (req, res) => {
   res.setHeader('Connection', 'keep-alive');
   res.flushHeaders();
 
+  // Tell clients how long to wait before retrying
+  res.write(`retry: 10000\n\n`);
+
   const clientId = Date.now();
-  const client = { id: clientId, res };
+  const symbolsParam = req.query.symbols;
+  const symbols = symbolsParam
+    ? symbolsParam.split(',').filter((s) => cryptoSymbols.includes(s))
+    : cryptoSymbols;
+  const client = { id: clientId, res, symbols };
   clients.push(client);
+
+  // Send initial snapshot of subscribed symbols
+  const snapshot = symbols.map((s) => ({
+    symbol: s,
+    price: parseFloat(prices[s].toFixed(2)),
+  }));
+  res.write(`id: ${eventId++}\n`);
+  res.write('event: snapshot\n');
+  res.write(`data: ${JSON.stringify(snapshot)}\n\n`);
 
   console.log(`Client connected: ${clientId} (total: ${clients.length})`);
 
@@ -40,11 +57,21 @@ function broadcastPrices() {
       price: parseFloat(prices[symbol].toFixed(2)),
     };
 
-    const message = `data: ${JSON.stringify(update)}\n\n`;
+    const message = `id: ${eventId++}\nevent: price-update\n` +
+      `data: ${JSON.stringify(update)}\n\n`;
 
-    clients.forEach((client) => client.res.write(message));
+    clients.forEach((client) => {
+      if (client.symbols.includes(symbol)) {
+        client.res.write(message);
+      }
+    });
   }
 }
+
+// Heartbeat comments to keep connections alive
+setInterval(() => {
+  clients.forEach((c) => c.res.write(':heartbeat\n\n'));
+}, 10000);
 
 setInterval(broadcastPrices, 2000);
 


### PR DESCRIPTION
## Summary
- add snapshot/id events, heartbeat, and symbol subscriptions to SSE server
- improve frontend with connection status and automatic retries
- simplify Gatling load test and parameterize user injection patterns

## Testing
- `npm test` *(sse-demo-app)* – `Missing script: "test"`
- `npm test` *(frontend)* – `Could not read package.json`
- `npm test` *(gatling-load-test/typescript)* – `Missing script: "test"`


------
https://chatgpt.com/codex/tasks/task_b_68958e96f8c0832f873867a0023c34b2