### PR TITLE
Fix SSE Gatling jmesPath check for snapshot message

### DIFF
--- a/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
+++ b/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
@@ -6,7 +6,8 @@ import {
   global,
   scenario,
   pause,
-  jmesPath
+  jmesPath,
+  substring
 } from "@gatling.io/core";
 import { http, sse } from "@gatling.io/http";
 
@@ -23,7 +24,12 @@ export default simulation((setUp) => {
     sse("Connect to /prices")
       .get("/prices")
       .await(10)
-      .on(sse.checkMessage("snapshot").check(jmesPath("symbol").exists())),
+      .on(
+        sse
+          .checkMessage("snapshot")
+          .matching(substring("event: snapshot"))
+          .check(jmesPath("[0].symbol").exists())
+      ),
     // Keep the connection open for the duration of the test
     pause(Math.max(duration, 0)),
     sse("Close SSE connection").close()


### PR DESCRIPTION
## Summary
- ensure SSE load test filters snapshot event before checking
- validate first snapshot entry's symbol with correct JMESPath

## Testing
- `npm run format`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68960e279d60832f8388066289c0928a