### PR TITLE
Expose SSE demo via ngrok for remote Gatling tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@
 
 ```bash
 docker-compose up --build
+```
+
+This launches the SSE demo application on `localhost:3000` and an `ngrok` tunnel so the app can be reached from a remote network.
+
+The `ngrok` container logs the public URL when it starts. Use that URL as the `BASE_URL` for the Gatling load tests when running them on Gatling Enterprise or any remote machine. If `BASE_URL` is not set, the tests default to `http://localhost:3000`.
+
+Optionally, provide your ngrok auth token when starting the stack:
+
+```bash
+NGROK_AUTHTOKEN=<your-token> docker-compose up --build
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,11 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
+
+  ngrok:
+    image: ngrok/ngrok:latest
+    command: http sse-app:3000
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    depends_on:
+      - sse-app

--- a/gatling-load-test/README.md
+++ b/gatling-load-test/README.md
@@ -49,3 +49,7 @@ npm run build # Build project but don't run
 npm run basicSimulation # Run the included basicSimulation simulation
 npm run recorder # Starts the Gatling Recorder
 ```
+
+### Targeting a remote application
+
+Both simulations read the target URL from the `BASE_URL` environment variable. When running the load tests from Gatling Enterprise or any remote machine, set `BASE_URL` to the public address of your locally running app (for example, the URL printed by the ngrok container).

--- a/gatling-load-test/javascript/src/basicSimulation.gatling.js
+++ b/gatling-load-test/javascript/src/basicSimulation.gatling.js
@@ -11,7 +11,7 @@ import { http, sse } from "@gatling.io/http";
 
 // Define the simulation
 export default simulation((setUp) => {
-  const baseUrl = "http://localhost:3000";
+  const baseUrl = process.env.BASE_URL || "http://localhost:3000";
 
   const httpProtocol = http.baseUrl(baseUrl);
 

--- a/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
+++ b/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
@@ -9,9 +9,11 @@ import {
 } from "@gatling.io/core";
 import { http, sse } from "@gatling.io/http";
 
+declare const process: { env: { [key: string]: string | undefined } };
+
 // Define the simulation
 export default simulation((setUp) => {
-  const baseUrl = "http://localhost:3000";
+  const baseUrl = process.env.BASE_URL || "http://localhost:3000";
 
   const httpProtocol = http.baseUrl(baseUrl);
 


### PR DESCRIPTION
## Summary
- add ngrok sidecar in docker-compose to tunnel the local SSE app
- allow Gatling simulations to read base URL from BASE_URL env
- document ngrok usage and remote testing configuration

## Testing
- `docker compose config` *(fails: command not found)*
- `apt-get install -y docker.io` *(fails: Unable to locate package)*
- `npm --prefix gatling-load-test/typescript run build`
- `npm --prefix gatling-load-test/javascript run build`


------
https://chatgpt.com/codex/tasks/task_b_6899c12806c0832fbb52d5a1893202db