### PR TITLE
Expose SSE demo via ngrok for remote Gatling tests

### DIFF
--- a/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
+++ b/gatling-load-test/typescript/src/ssePriceFeed.gatling.ts
@@ -9,11 +9,13 @@ import {
 } from "@gatling.io/core";
 import { http, sse } from "@gatling.io/http";
 
-declare const process: { env: { [key: string]: string | undefined } };
+// Gatling's JavaScript engine exposes the Java interop API
+declare const Java: any;
 
 // Define the simulation
 export default simulation((setUp) => {
-  const baseUrl = process.env.BASE_URL || "http://localhost:3000";
+  const System = Java.type("java.lang.System");
+  const baseUrl = System.getenv("BASE_URL") || "http://localhost:3000";
 
   const httpProtocol = http.baseUrl(baseUrl);
 


### PR DESCRIPTION
## Summary
- add ngrok sidecar in docker-compose to tunnel the local SSE app
- allow Gatling simulations to read base URL from BASE_URL env
- document ngrok usage and remote testing configuration
- use Java System access in TypeScript simulation to avoid missing `process` variable

## Testing
- `docker-compose config`
- `npm --prefix gatling-load-test/typescript run build`
- `npm --prefix gatling-load-test/javascript run build`


------
https://chatgpt.com/codex/tasks/task_b_6899c12806c0832fbb52d5a1893202db