### PR TITLE
docs: add project structure map

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,20 @@ This repository demonstrates a complete workflow for load testing a Server-Sent 
 
 ## 📁 Project Structure
 
+```
+.
+├── frontend/        # Browser client for viewing SSE streams
+├── gatling/         # Load-testing scripts and config
+│   ├── javascript/
+│   │   ├── src/        # JS simulations
+│   │   └── resources/  # JS assets (conf, feeders)
+│   └── typescript/
+│       ├── src/        # TS simulations
+│       └── resources/  # TS assets (conf, feeders)
+└── sse-demo-app/   # Node.js SSE demo server
+```
 
-**Purpose:**  
+**Purpose:**
 Showcase how to build, run, and load test a modern SSE service using Gatling JS, with a focus on reproducibility, remote testing, and best practices for test-as-code.
 
 ## 🚀 Running the Full Demo with Docker & Gatling Enterprise


### PR DESCRIPTION
## Summary
- document root folders and Gatling JS/TS substructure in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2be525c70832f80313cfc6c359169